### PR TITLE
fix(security): ci-run uses env-only --secret form to keep token out of argv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,14 +230,16 @@ ci-run: deps-act
 	@docker container prune -f 2>/dev/null || true
 	@evt=$$(mktemp /tmp/act-push-event.XXXXXX.json); \
 	printf '{"ref":"refs/heads/main","repository":{"default_branch":"main","name":"$(APP_NAME)","full_name":"AndriyKalashnykov/$(APP_NAME)"}}' >"$$evt"; \
+	secret_args=(); \
+	[ -n "$$NVD_API_KEY" ] && secret_args+=(--secret NVD_API_KEY); \
+	[ -n "$$OSS_INDEX_USER" ] && secret_args+=(--secret OSS_INDEX_USER); \
+	[ -n "$$OSS_INDEX_TOKEN" ] && secret_args+=(--secret OSS_INDEX_TOKEN); \
 	act push -W .github/workflows/ci.yml \
 		--container-architecture linux/amd64 \
 		--artifact-server-path /tmp/act-artifacts \
 		--eventpath "$$evt" \
 		--var ACT=true \
-		$$([ -n "$$NVD_API_KEY" ] && echo "--secret NVD_API_KEY=$$NVD_API_KEY") \
-		$$([ -n "$$OSS_INDEX_USER" ] && echo "--secret OSS_INDEX_USER=$$OSS_INDEX_USER") \
-		$$([ -n "$$OSS_INDEX_TOKEN" ] && echo "--secret OSS_INDEX_TOKEN=$$OSS_INDEX_TOKEN"); \
+		"$${secret_args[@]}"; \
 	rc=$$?; rm -f "$$evt"; exit $$rc
 
 #release: @ Create a release (usage: make release VERSION=x.y.z)


### PR DESCRIPTION
## Summary

The current `make ci-run` recipe interpolates `--secret KEY=$VALUE` for `NVD_API_KEY`, `OSS_INDEX_USER`, and `OSS_INDEX_TOKEN`. This puts the secret values into argv, where any local user can read them via `ps -ef`, `pgrep -af`, or `/proc/<pid>/cmdline` for the lifetime of the run. The leak persists in any system that snapshots process state (auditd, observability agents, container-runtime captures, CI log archives).

This switches to a bash array of conditional `--secret KEY` flags. `act` reads the value from the recipe's inherited process env when only the key name is on the command line — the value never enters argv.

Same root cause as `dapr-nodejs-nextjs#158` (a real incident in the portfolio: `GH_ACCESS_TOKEN` leaked into a session log via `ps`). The canonical fix pattern is now codified in the `/makefile` skill §10 rule #9 plus the global rule in `claude-config rules/common/security.md`.

## Test plan

- [ ] `make -n ci-run` parses cleanly and shows the new bash-array expansion
- [ ] `make ci-run` runs end-to-end with all three secrets set in env
- [ ] `make ci-run` runs with no secrets set (array stays empty, act invocation succeeds without `--secret` flags)