### PR TITLE
chore: project-review pass — mise-action CI, Jackson/WireMock bumps, slim backlog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,9 @@ jobs:
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
-          base: main
+          # `base` is consulted only on push events; on pull_request the action uses
+          # PR.base.ref and emits a warning if `base` is set. Gate via expression.
+          base: ${{ github.event_name == 'push' && 'main' || '' }}
           filters: |
             code:
               - '!(**.md|docs/**|specs/**|LICENSE|.gitignore|.claudeignore|.claude/**|benchmarks/**|**.png|**.jpg|**.gif|**.svg)'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Detect path filter
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
+          base: main
           filters: |
             code:
               - '!(**.md|docs/**|specs/**|LICENSE|.gitignore|.claudeignore|.claude/**|benchmarks/**|**.png|**.jpg|**.gif|**.svg)'
@@ -49,15 +50,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      - name: Set up mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          java-version-file: .java-version
-          distribution: 'temurin'
-          cache: 'maven'
+          install: true
+          cache: true
 
-      - name: Install Maven
-        run: make deps-maven
+      - name: Cache Maven repository
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ hashFiles('pom.xml') }}
+          restore-keys: maven-
 
       - name: Static check
         run: make static-check
@@ -71,15 +75,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up JDK
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      - name: Set up mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          java-version-file: .java-version
-          distribution: 'temurin'
-          cache: 'maven'
+          install: true
+          cache: true
 
-      - name: Install Maven
-        run: make deps-maven
+      - name: Cache Maven repository
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ hashFiles('pom.xml') }}
+          restore-keys: maven-
+
+      - name: Test with coverage
+        run: make coverage-generate
 
       - name: Verify coverage threshold
         run: make coverage-check
@@ -103,15 +113,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up JDK
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      - name: Set up mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          java-version-file: .java-version
-          distribution: 'temurin'
-          cache: 'maven'
+          install: true
+          cache: true
 
-      - name: Install Maven
-        run: make deps-maven
+      - name: Cache Maven repository
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ hashFiles('pom.xml') }}
+          restore-keys: maven-
 
       - name: Integration test
         run: make integration-test
@@ -125,15 +138,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up JDK
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      - name: Set up mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          java-version-file: .java-version
-          distribution: 'temurin'
-          cache: 'maven'
+          install: true
+          cache: true
 
-      - name: Install Maven
-        run: make deps-maven
+      - name: Cache Maven repository
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ hashFiles('pom.xml') }}
+          restore-keys: maven-
 
       - name: Build
         run: make build
@@ -147,15 +163,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up JDK
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      - name: Set up mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          java-version-file: .java-version
-          distribution: 'temurin'
-          cache: 'maven'
+          install: true
+          cache: true
 
-      - name: Install Maven
-        run: make deps-maven
+      - name: Cache Maven repository
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ hashFiles('pom.xml') }}
+          restore-keys: maven-
 
       - name: Cache NVD database
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,5 @@
 [tools]
-# renovate: datasource=java-version depName=java
+# renovate: datasource=adoptium-java depName=java
 java = "temurin-25.0.3+9.0.LTS"
 # renovate: datasource=maven depName=org.apache.maven:apache-maven
 maven = "3.9.15"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Educational Java project demonstrating HTTP client implementations and JSON pars
 ```bash
 make help               # List available tasks
 make deps               # Check tools; auto-install mise (no root) + mise-pinned Java/Maven
-make deps-maven         # Install Maven into ~/.local (CI fallback when setup-java is unavailable)
+make deps-maven         # Install Maven into ~/.local (act-runner fallback when mise is unavailable)
 make deps-install       # Install Java and Maven via mise (reads .mise.toml)
 make deps-act           # Install act into ~/.local/bin (no root)
 make deps-gitleaks      # Install gitleaks into ~/.local/bin
@@ -35,8 +35,6 @@ make coverage-check     # Verify coverage meets 70% threshold
 make coverage-open      # Open code coverage report
 make cve-check          # OWASP CVE scan (slow, not part of normal workflow)
 make vulncheck          # Alias for cve-check
-make deps-updates       # Print available dependency updates
-make deps-update        # Update dependencies to latest releases
 make deps-prune         # Analyze declared-but-unused / used-but-undeclared dependencies
 make deps-prune-check   # Fail build on declared-but-unused dependencies
 make release VERSION=x.y.z  # Tag and push a release
@@ -58,6 +56,10 @@ Two independent module areas under `src/main/java/`:
   - `databinding/simple/` — POJO mapping with Jackson and Gson
   - `databinding/complex/` — Generated model classes for full NASA NEO response (separate `jackson/generated/` and `gson/generated/` packages)
   - `pathqueries/` — JsonPath and Jackson JsonPointer queries
+
+### Notable design decisions
+
+- **Jackson cross-major split** — `tools.jackson.core:jackson-databind` 3.x reuses the legacy `com.fasterxml.jackson.core:jackson-annotations` 2.x coordinate (Jackson 3 didn't move the annotations package). The `jsonparse/databinding/complex/jackson/generated/` POJOs import `com.fasterxml.jackson.annotation.*` — this is intentional, not a migration leftover.
 
 ## Testing
 
@@ -89,27 +91,20 @@ Run `make format` to auto-apply google-java-format. `cve-check` (OWASP dependenc
 ## Key Config
 
 - **pom.xml** — maven-enforcer-plugin requires Maven 3.6.3+ and Java 25+; JaCoCo 70% threshold; compiler `failOnWarning` enabled; Jackson 3.x (`tools.jackson.core`); OWASP dependency-check bound to build lifecycle (skip with `-Ddependency-check.skip=true`); Failsafe plugin activated via `-P integration-test` profile
-- **.mise.toml** — single source of truth for Java (Temurin 25 LTS), Maven 3.9.15, and aqua-backed pins for `act`, `gitleaks`, `trivy`; auto-installed by `make deps`. The Makefile's matching `_VERSION` constants are derived at parse time via `$(shell awk ...)` so the curl fallbacks in `deps-maven` / `deps-act` / `deps-gitleaks` / `deps-trivy` (used inside CI containers with setup-java but no mise) read the same version mise installs locally.
-- **.java-version** — single source of truth consumed by GitHub Actions `setup-java`
+- **.mise.toml** — single source of truth for Java (Temurin 25 LTS), Maven 3.9.15, and aqua-backed pins for `act`, `gitleaks`, `trivy`; auto-installed by `make deps`. CI provisions the toolchain via [`jdx/mise-action`](https://github.com/jdx/mise-action). The Makefile's matching `_VERSION` constants are derived at parse time via `$(shell awk ...)` so the curl fallbacks (`deps-maven` / `deps-act` / `deps-gitleaks` / `deps-trivy`) used by `act` runners without mise read the same version mise installs locally.
+- **.java-version** — secondary source of truth (IDE integration); `.mise.toml` is authoritative for build/CI
 - **.nvmrc** — Node version for Renovate tooling (`make renovate-bootstrap`)
-- **renovate.json** — Automated dependency PRs with automerge on all update types
-- **CI pipeline** — `changes` (path-filter detector via `dorny/paths-filter`) → `static-check` → `test` + `integration-test` + `build` (parallel); `cve-check` on release tags, weekly schedule (Mon 06:00 UTC), and manual dispatch, with NVD database cache; `ci-pass` gate aggregates all required jobs for branch protection (skipped doc-only jobs count as pass)
+- **renovate.json** — Automated dependency PRs with automerge on all update types. `RENOVATE_VERSION` in the Makefile tracks the `npm` datasource (not `github-releases`) because Renovate's GitHub releases run ~8 versions ahead of npm publishes; `npx renovate@<ver>` resolves via npm. Detection: `make renovate-validate` failing with `npm error notarget No matching version found for renovate@<ver>` means the datasource is mismatched.
+- **CI pipeline** — `changes` (path-filter detector via `dorny/paths-filter`) → `static-check` → `test` + `integration-test` + `build` (parallel); `cve-check` on release tags, weekly schedule (Mon 06:00 UTC), and manual dispatch, with NVD database cache; `ci-pass` gate aggregates all required jobs for branch protection (skipped doc-only jobs count as pass). Required GitHub secrets (set in Settings > Secrets and variables > Actions): `NVD_API_KEY`, `OSS_INDEX_USER`, `OSS_INDEX_TOKEN` — without `NVD_API_KEY` the tag-gated `cve-check` will hit NVD rate limits and fail.
 
 ## Upgrade Backlog
 
-Deferred items surfaced by `/upgrade-analysis` — revisit on the next review pass.
+Items genuinely waiting on upstream — Renovate cannot bump these until the upstream channel makes them available.
 
-- [ ] `.mise.toml` Java tuple is not cleanly tracked by Renovate's `java-version` datasource; bump manually each Adoptium quarterly GA, or switch to `adoptium-java` datasource if Renovate stalls. (Currently pinned at `temurin-25.0.3+9.0.LTS`.)
-- [ ] `jdk.incubator.vector` is still an incubator module as of Java 25 — the `--add-modules jdk.incubator.vector` flag in `cve-check` should be removed if/when the module is promoted out of incubator.
+- [ ] `jdk.incubator.vector` is still an incubator module as of Java 25 (still incubating in JEP 510 / 8th-round). The `--add-modules jdk.incubator.vector` flag in the `cve-check` recipe is required because OWASP dependency-check's bundled Lucene uses the Vector API. Drop the flag once Vector is promoted out of incubator (expected Java 26+).
 - [ ] `maven.compiler.failOnWarning=true` will make JDK deprecation warnings upgrade-blocking on future LTS bumps (Java 29+). Plan a targeted deprecation audit before each LTS bump.
-- [ ] Retrofit 3.x ⇔ OkHttp 5.x is the only supported pairing — keep these bumped together. Renovate groups them separately; watch for version drift.
-- [ ] JsonPath 3.0.0 is the first 3.x GA (January 2025); watch 3.1 release notes for behavioural changes that may affect `jsonparse/pathqueries/`.
-- [ ] JUnit 6.1.0 (currently `6.1.0-RC1`), SLF4J 2.1.0 (alpha), `maven-compiler-plugin` 4.0.0 (currently `beta-4`), `maven-resources-plugin` 4.0.0 (beta), and WireMock 4.0.0 (beta) are all pre-release — adopt after GA.
-- [ ] Jackson is on the deliberate cross-major split: `tools.jackson.core:jackson-databind` 3.x reuses the legacy `com.fasterxml.jackson.core:jackson-annotations` 2.x coordinate (Jackson 3 didn't move the annotations package). The `jsonparse/databinding/complex/jackson/generated/` POJOs import `com.fasterxml.jackson.annotation.*` — this is intentional, not a migration leftover.
-- [ ] `dorny/paths-filter` v4.0.1 is now available; the project just adopted v3.0.2. v4 has shape changes — let Renovate open the major PR with migration notes attached, do not fast-follow.
-- [ ] `RENOVATE_VERSION` tracks the `npm` datasource (not `github-releases`) because Renovate's GitHub releases run ~8 versions ahead of npm publishes (the consumable channel for `npx renovate@<ver>`). If Renovate ever flips publish cadence and the npm package catches up to GitHub, switching the datasource back to `github-releases` is fine. Detection: `make renovate-validate` failing with `npm error notarget No matching version found for renovate@<ver>` means the datasource is mismatched.
-- [ ] `NVD_API_KEY` GitHub secret must be set before tagging a release or the tag-gated `cve-check` job will fail (NVD rate limit without a key). The job also runs weekly on schedule and via `workflow_dispatch`.
-- [ ] `make deps-update` bulk-bumps dependencies; with Renovate as the source of truth, treat this target as manual-only — consider deleting or guarding with a "bypasses Renovate" warning.
+- [ ] JsonPath 3.1 not yet released — latest GA is `3.0.0` (2026-02-22). Watch release notes for behavioural changes that may affect `jsonparse/pathqueries/` when it ships.
+- [ ] Pre-release deps awaiting GA: JUnit 6.1.0 (currently `6.1.0-RC1`), SLF4J 2.1.0 (alpha), `maven-compiler-plugin` 4.0.0 (currently `beta-4`), `maven-resources-plugin` 4.0.0 (beta). Adopt after GA. SLF4J 2.0.x and JUnit 6.0.x are both on latest GA.
 
 ## Skills
 

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,14 @@ help:
 	@grep -E '[a-zA-Z\.\-]+:.*?@ .*$$' $(MAKEFILE_LIST)| tr -d '#' | awk 'BEGIN {FS = ":.*?@ "}; {printf "\033[32m%-30s\033[0m - %s\n", $$1, $$2}'
 
 #deps: @ Check required tools; auto-install mise (no root) and mise-pinned tools if missing
+# `mise install` runs unconditionally — in CI, jdx/mise-action has already provisioned mise
+# and the toolchain, so this becomes a no-op. The `[ -z "$$CI" ]` guard is reserved for
+# the curl bootstrap (mise itself isn't on the runner before jdx/mise-action runs).
 deps:
-	@if [ -z "$$CI" ] && ! command -v mise >/dev/null 2>&1; then \
+	@if ! command -v mise >/dev/null 2>&1; then \
+		if [ -n "$$CI" ]; then \
+			echo "Error: mise not found in CI; jdx/mise-action should have installed it"; exit 1; \
+		fi; \
 		echo "Installing mise (no root required, installs to ~/.local/bin)..."; \
 		curl -fsSL https://mise.run | sh; \
 		echo ""; \
@@ -58,7 +64,7 @@ deps:
 		echo '  zsh:  echo '\''eval "$$(~/.local/bin/mise activate zsh)"''  >> ~/.zshrc'; \
 		exit 0; \
 	fi
-	@if [ -z "$$CI" ] && command -v mise >/dev/null 2>&1; then mise install; fi
+	@mise install
 	@command -v java >/dev/null 2>&1 || mise exec -- command -v java >/dev/null 2>&1 || { echo "Error: Java required. Run: make deps-install"; exit 1; }
 	@command -v mvn  >/dev/null 2>&1 || mise exec -- command -v mvn  >/dev/null 2>&1 || { echo "Error: Maven required. Run: make deps-install"; exit 1; }
 	@echo "All required dependencies are available"
@@ -74,15 +80,13 @@ deps-maven:
 
 #deps-install: @ Install Java and Maven via mise (reads .mise.toml)
 deps-install:
+	@command -v mise >/dev/null 2>&1 || { echo "Installing mise..."; curl -fsSL https://mise.run | sh; }
+	@mise install
 	@if [ -z "$$CI" ]; then \
-		command -v mise >/dev/null 2>&1 || { echo "Installing mise..."; curl -fsSL https://mise.run | sh; }; \
-		mise install; \
 		echo ""; \
 		echo "Tools installed. If this is a fresh install, activate mise in your shell:"; \
 		echo "  bash: echo 'eval \"\$$(~/.local/bin/mise activate bash)\"' >> ~/.bashrc"; \
 		echo "  zsh:  echo 'eval \"\$$(~/.local/bin/mise activate zsh)\"'  >> ~/.zshrc"; \
-	else \
-		echo "CI environment detected; skipping mise install (toolchain provided by workflow)."; \
 	fi
 
 #deps-act: @ Install act for local CI (installs to ~/.local/bin, no root)
@@ -349,17 +353,8 @@ renovate-validate: renovate-bootstrap
 		npx --yes renovate@$(RENOVATE_VERSION) --platform=local; \
 	fi
 
-#deps-updates: @ Print project dependencies updates
-deps-updates: deps
-	@mvn -B versions:display-dependency-updates
-
-#deps-update: @ Update project dependencies to latest releases
-deps-update: deps-updates
-	@mvn -B versions:use-latest-releases
-	@mvn -B versions:commit
-
 .PHONY: help deps deps-maven deps-install deps-act deps-gitleaks deps-trivy deps-docker deps-check \
-	deps-updates deps-update deps-prune deps-prune-check \
+	deps-prune deps-prune-check \
 	clean build test integration-test lint format format-check secrets trivy-fs mermaid-lint static-check \
 	ci ci-run release vulncheck cve-check \
 	coverage-generate coverage-check coverage-open \

--- a/README.md
+++ b/README.md
@@ -9,22 +9,33 @@ Side-by-side comparison of five Java HTTP clients (`HttpURLConnection`, `java.ne
 
 ```mermaid
 flowchart LR
-    App["Example main() classes"] --> HC{HTTP Clients}
-    HC -->|"GET /neo/rest/v1/feed"| API[("NASA NEO API")]
-    API -->|JSON| JP{JSON Parsers}
-    JP --> App
+    App["Example main() classes<br/>Java 25"]
+    NEO[("NASA NEO API<br/>api.nasa.gov")]
 
-    HC --- HC1[HttpURLConnection]
-    HC --- HC2["java.net.http.HttpClient"]
-    HC --- HC3[Apache HttpClient 5]
-    HC --- HC4[OkHttp]
-    HC --- HC5[Retrofit]
+    subgraph HTTPC["HTTP Clients"]
+        direction TB
+        HC1["HttpURLConnection (JDK)"]
+        HC2["java.net.http.HttpClient (JDK 11+)"]
+        HC3["Apache HttpClient 5.6.1"]
+        HC4["OkHttp 5.3.2"]
+        HC5["Retrofit 3.0.0"]
+    end
 
-    JP --- JP1["Jackson tree + databind"]
-    JP --- JP2["Gson tree + databind"]
-    JP --- JP3[JsonPath]
-    JP --- JP4[Jackson JsonPointer]
+    subgraph JSONP["JSON Parsers"]
+        direction TB
+        JP1["Jackson 3.1.3 (tree + databind)"]
+        JP2["Gson 2.14.0 (tree + databind)"]
+        JP3["JsonPath 3.0.0"]
+        JP4["Jackson JsonPointer 3.1.3"]
+    end
+
+    App --> HTTPC
+    HTTPC -->|"GET /neo/rest/v1/feed"| NEO
+    NEO -->|"JSON"| JSONP
+    JSONP --> App
 ```
+
+Each `main()` class under `src/main/java/` issues the same `GET /neo/rest/v1/feed` request via one of the five HTTP clients, then deserializes the response via one of the four JSON-parsing approaches. The grid lets you compare ergonomics, dependency footprint, async support, and schema handling side-by-side against an unchanging upstream call. Container labels carry library versions so the diagram tracks the Tech Stack table below.
 
 ## Tech Stack
 
@@ -35,7 +46,7 @@ flowchart LR
 | Tests | [JUnit Jupiter](https://junit.org/junit5/) 6.0.3 (unit) + [WireMock](https://wiremock.org/) 3.13.1 (integration via Failsafe `*IT.java`) |
 | Coverage | [JaCoCo](https://www.jacoco.org/jacoco/) (70% instruction + branch) |
 | HTTP clients | `java.net.HttpURLConnection`, `java.net.http.HttpClient`, [Apache HttpClient 5](https://hc.apache.org/) 5.6.1, [OkHttp](https://square.github.io/okhttp/) 5.3.2, [Retrofit](https://square.github.io/retrofit/) 3.0.0 |
-| JSON | [Jackson](https://github.com/FasterXML/jackson) 3.1.2 (`tools.jackson.core`), [Gson](https://github.com/google/gson) 2.14.0, [JsonPath](https://github.com/json-path/JsonPath) 3.0.0 |
+| JSON | [Jackson](https://github.com/FasterXML/jackson) 3.1.3 (`tools.jackson.core`), [Gson](https://github.com/google/gson) 2.14.0, [JsonPath](https://github.com/json-path/JsonPath) 3.0.0 |
 | Formatting | [google-java-format](https://github.com/google/google-java-format) |
 | Security | [gitleaks](https://github.com/gitleaks/gitleaks), [Trivy](https://github.com/aquasecurity/trivy), [OWASP dependency-check](https://dependency-check.github.io/DependencyCheck/) |
 | CI | GitHub Actions; local replay via [act](https://github.com/nektos/act) |
@@ -175,9 +186,8 @@ Listed below; `make help` prints the same list.
 | `make deps-act` | Install `act` into `~/.local/bin` |
 | `make deps-gitleaks` | Install `gitleaks` into `~/.local/bin` |
 | `make deps-trivy` | Install `trivy` into `~/.local/bin` |
+| `make deps-docker` | Verify Docker is available (internal helper for `mermaid-lint`; skipped under act) |
 | `make deps-check` | Show required tools and installation status |
-| `make deps-updates` | Print available dependency updates |
-| `make deps-update` | Update dependencies to latest releases |
 | `make deps-prune` | Analyze declared-but-unused / used-but-undeclared dependencies |
 | `make deps-prune-check` | Fail build on declared-but-unused dependencies |
 
@@ -199,7 +209,7 @@ GitHub Actions runs on every push to `main`, tags `v*`, pull requests, a weekly 
 |-----|----------|------|
 | `changes` | every event | [`dorny/paths-filter`](https://github.com/dorny/paths-filter) detector — gates heavy jobs so doc-only changes skip CI without deadlocking the `ci-pass` required check |
 | `static-check` | after `changes` (when code changes) | `make static-check` (format-check + lint + gitleaks + Trivy filesystem scan + mermaid-lint + deps-prune-check) |
-| `test` | after `changes` + `static-check` | `make coverage-check` (transitively runs tests + `jacoco:report`; uploads `coverage-report` artifact) |
+| `test` | after `changes` + `static-check` | `make coverage-generate` (tests + `jacoco:report`) then `make coverage-check` (70% threshold); uploads `coverage-report` artifact |
 | `integration-test` | after `changes` + `static-check` | `make integration-test` (WireMock-stubbed HTTP client tests) |
 | `build` | after `changes` + `static-check` | `make build` |
 | `cve-check` | tags `v*`, weekly schedule, manual dispatch | `make cve-check` with cached NVD database (uploads `cve-report` artifact) |

--- a/pom.xml
+++ b/pom.xml
@@ -91,14 +91,14 @@
         <dependency>
             <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>3.1.2</version>
+            <version>3.1.3</version>
         </dependency>
 
         <!-- Declared directly: tree-model code references jackson-core types (transitive of jackson-databind) -->
         <dependency>
             <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>3.1.2</version>
+            <version>3.1.3</version>
         </dependency>
 
         <!-- Jackson 3.x reuses the legacy 2.x annotations coordinate (com.fasterxml.jackson.annotation.*).
@@ -168,7 +168,7 @@
         <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
-            <version>3.13.1</version>
+            <version>3.13.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/renovate.json
+++ b/renovate.json
@@ -87,16 +87,10 @@
       ]
     },
     {
-      "description": "Group OkHttp dependencies (including KMP -jvm artifacts)",
-      "groupName": "OkHttp",
+      "description": "Group Retrofit + OkHttp into one PR — Retrofit 3.x ⇔ OkHttp 5.x is the only supported pairing; bumping them together prevents version drift.",
+      "groupName": "Retrofit + OkHttp",
       "matchPackageNames": [
-        "/^com\\.squareup\\.okhttp3/"
-      ]
-    },
-    {
-      "description": "Group Retrofit dependencies",
-      "groupName": "Retrofit",
-      "matchPackageNames": [
+        "/^com\\.squareup\\.okhttp3/",
         "/^com\\.squareup\\.retrofit2/"
       ]
     },


### PR DESCRIPTION
## Summary

Project-review hardening pass — all findings addressed plus the upgrade backlog reduced from 11 items to 4.

### CI / toolchain
- Migrate every CI job from `actions/setup-java` to `jdx/mise-action@v4.0.1` (SHA-pinned). `.mise.toml` is now the single toolchain source for both local dev and CI; the `Install Maven` step is gone.
- Restructure `make deps` so `mise install` runs unconditionally — only the `curl https://mise.run` bootstrap is `[ -z "$$CI" ]`-guarded. `make deps-install` no longer has a CI-skip branch.
- Bump `dorny/paths-filter` v3.0.2 → v4.0.1 (Node 24 runtime).
- Add explicit `base: main` to the `paths-filter` step.
- Split the `test` job's coverage step into `Test with coverage` + `Verify coverage threshold` for clarity.

### Dependency bumps
- Jackson `tools.jackson.core:jackson-databind` + `jackson-core` 3.1.2 → 3.1.3 (latest GA on 3.x).
- WireMock 3.13.1 → 3.13.2.
- `jackson-annotations` stays on 2.21 — the 3.0 line is still pre-release upstream.

### Renovate
- Switch `.mise.toml` Java pin from `datasource=java-version` to `adoptium-java`.
- Merge the separate `OkHttp` and `Retrofit` package groups into a single `Retrofit + OkHttp` group — Retrofit 3.x ⇔ OkHttp 5.x is the only supported pairing.

### Makefile
- Delete `make deps-update` and `make deps-updates` targets (Renovate is the single source of truth for dependency bumps).

### README
- Redraw the hero diagram with library version strings (`Apache HttpClient 5.6.1`, `OkHttp 5.3.2`, `Retrofit 3.0.0`, `Jackson 3.1.3`, `Gson 2.14.0`, `JsonPath 3.0.0`), `subgraph` grouping in place of unlabeled `---` membership edges, and a 3-sentence prose caption explaining the round-trip flow.
- Add `make deps-docker` to the Make Targets table.
- Update CI/CD job description for the two-step coverage pattern.

### CLAUDE.md
- Move the Jackson cross-major split design note from the upgrade backlog into Architecture > Notable design decisions.
- Append `RENOVATE_VERSION` npm-datasource explanation and the required-secrets list (NVD_API_KEY, OSS_INDEX_USER, OSS_INDEX_TOKEN) to Key Config.
- Slim the upgrade backlog from 11 items to 4 — only items genuinely waiting on upstream remain (Vector API incubator, Java 29+ deprecation audit, JsonPath 3.1, remaining pre-release deps).

## Test plan
- [x] `make ci-run` — all four jobs (`static-check`, `test`, `integration-test`, `build`) pass under act with the new `jdx/mise-action` workflow.
- [x] `act push --job changes` — `dorny/paths-filter` v4.0.1 runs cleanly.
- [x] `make ci` — BUILD SUCCESS with Jackson 3.1.3 + WireMock 3.13.2.
- [x] `make renovate-validate` — config parses; 62 deps tracked across 5 files.
- [ ] Watch the GitHub Actions CI run on this PR for cleanliness — including the `cve-check` weekly schedule (deferred — runs on tag/schedule/dispatch only).