### PR TITLE
fix(security): bump Jackson 3.1.3 → 3.1.4 (CVE-2026-54512, CVE-2026-54513)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,14 +91,14 @@
         <dependency>
             <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>3.1.3</version>
+            <version>3.1.4</version>
         </dependency>
 
         <!-- Declared directly: tree-model code references jackson-core types (transitive of jackson-databind) -->
         <dependency>
             <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>3.1.3</version>
+            <version>3.1.4</version>
         </dependency>
 
         <!-- Jackson 3.x reuses the legacy 2.x annotations coordinate (com.fasterxml.jackson.annotation.*).


### PR DESCRIPTION
## Root cause

The weekly scheduled CI run (\`28355945300\`, and the prior week's) failed on an **unchanged \`main\` SHA** (\`22be811\`). The \`static-check\` → \`trivy-fs\` step went red because Trivy's vulnerability DB drifted — not the code:

\`\`\`
pom.xml (pom)  Total: 2 (HIGH: 2, CRITICAL: 0)
tools.jackson.core:jackson-databind  CVE-2026-54512  HIGH  fixed  3.1.3 → 3.1.4
                                     CVE-2026-54513  HIGH  fixed  (security bypass → arbitrary code execution)
\`\`\`

This is the "diagnose \`main\`, not the PR" / stale-green-is-not-mergeable-green pattern: a check that was green last week is red today because the scanner learned about two freshly-disclosed CVEs.

## Fix

Bump \`jackson-databind\` **and** \`jackson-core\` 3.1.3 → 3.1.4 (the exact fixed version Trivy names). Both bumped in lockstep to keep the Jackson 3.1.x release train aligned (databind 3.1.4 depends on core 3.1.4). Minimal patch bump = lowest regression risk; Renovate can take it to 3.2.0 later through its normal automerge flow.

## Verification (local)

| Gate | Result |
|------|--------|
| \`make trivy-fs\` | **2 HIGH → 0** (gate's RED in CI, GREEN on fix) |
| \`make static-check\` | rc=0 (the failing gate) |
| \`make test\` | 14/14 |
| \`make integration-test\` | 2/2 (WireMock Jackson databinding paths) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)