### PR TITLE
docs: README toolchain breadth + stale Make Targets; fix GitHub About (factual)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # Java HTTP Clients & JSON Parsing Reference
 
-Side-by-side comparison of five Java HTTP clients (`HttpURLConnection`, `java.net.http.HttpClient`, Apache HttpClient 5, OkHttp, Retrofit) and four JSON-parsing approaches (tree model, simple data binding, full-schema data binding, path queries) — **two independent demonstration tracks**. Each HTTP client issues the same `GET /api/article_users?page=2` request and parses it into a shared model, so client trade-offs (ergonomics, dependency footprint, async support) are directly comparable; each JSON-parsing demo processes the same bundled NASA Near-Earth Objects (NEO) feed snapshot, so parsing trade-offs (schema handling, query ergonomics) are directly comparable. It doubles as a build-tooling reference: a **JUnit 6 + WireMock** test pyramid, **gitleaks / Trivy / OWASP dependency-check** security gates, **JaCoCo** 70% coverage enforcement, and a **GitHub Actions** CI pipeline (locally replayable via `act`).
+Side-by-side comparison of five Java HTTP clients (`HttpURLConnection`, `java.net.http.HttpClient`, Apache HttpClient 5, OkHttp, Retrofit) and four JSON-parsing approaches (tree model, simple data binding, full-schema data binding, path queries) — **two independent demonstration tracks**. Each HTTP client issues the same `GET /api/article_users?page=2` request and parses it into a shared model, so client trade-offs (ergonomics, dependency footprint, async support) are directly comparable; each JSON-parsing demo processes the same bundled NASA Near-Earth Objects (NEO) feed snapshot, so parsing trade-offs (schema handling, query ergonomics) are directly comparable. It doubles as a build-tooling reference: a **JUnit 6 + WireMock** test pyramid, **google-java-format / gitleaks / Trivy / OWASP dependency-check** quality + security gates, **JaCoCo** 70% coverage enforcement, and a **GitHub Actions** CI pipeline (locally replayable via `act`) on a **mise**-pinned toolchain with **Renovate**-managed dependencies.
 
 ```mermaid
 flowchart LR
@@ -168,7 +168,8 @@ Listed below; `make help` prints the same list.
 | `make secrets` | Scan repository for hardcoded secrets (gitleaks) |
 | `make trivy-fs` | Filesystem vulnerability/secret/misconfig scan |
 | `make mermaid-lint` | Validate Mermaid diagrams in Markdown (requires Docker) |
-| `make static-check` | Composite fast quality gate (format-check + lint + secrets + trivy-fs + mermaid-lint + deps-prune-check) |
+| `make check-toolchain-alignment` | Fail if the Java major disagrees across `.java-version`, `.mise.toml`, `pom.xml` |
+| `make static-check` | Composite fast quality gate (check-toolchain-alignment + format-check + lint + secrets + trivy-fs + mermaid-lint + deps-prune-check) |
 | `make cve-check` | Run OWASP dependency vulnerability scan |
 | `make vulncheck` | Alias for `cve-check` |
 
@@ -176,7 +177,7 @@ Listed below; `make help` prints the same list.
 
 | Target | Description |
 |--------|-------------|
-| `make ci` | Run full CI pipeline (static-check, test, coverage-check, build) |
+| `make ci` | Run full CI pipeline (static-check, integration-test, coverage-check, build) |
 | `make ci-run` | Run GitHub Actions workflow locally using [act](https://github.com/nektos/act) |
 
 ### Dependencies


### PR DESCRIPTION
`/readme` review with the **self-review-bias guard active** (the README was edited earlier this session across PRs #344/#345/#348, by this agent). Re-derived from post-mutation state rather than trusting the existing prose.

## BLOCKING — GitHub About field was factually wrong (fixed via `gh`, outside this PR)
About read *"…all hitting NASA's NEO API…"* — the **same bug** just fixed in the diagram (#348). The HTTP clients hit `jsonmock.hackerrank.com/api/article_users`; only the JSON-parsing demos use a **bundled local** NASA NEO snapshot. About now reads two-independent-tracks, aligned with the README. Also dropped stale topics `log4j` (project uses slf4j) and `sdkman` (uses mise); added `mise`/`wiremock`/`jsonpath`.

## README fixes (this PR)
- **Description toolchain breadth** (bidirectional enumeration): the build-tooling sentence now names **google-java-format**, **mise** (pinned toolchain), and **Renovate** (dep automation) — they were in the Tech Stack table but missing from the description prose.
- **Stale `make ci` description**: `test` → `integration-test` (the `ci` target was deduped in #344 to run the unit suite via `coverage-check`, not a separate `test` step).
- **Stale `make static-check` description**: added `check-toolchain-alignment` (its new first prerequisite, added #344).
- **Missing target**: added the `check-toolchain-alignment` row to the Make Targets table.

## Verified clean (no action)
Section order canonical (Make Targets before CI/CD; no Build/Deploy needed for a library); badges correct (CI/Hits/License/Renovate); Tech Stack versions all match `pom.xml` (Jackson 3.1.4, WireMock 3.13.2, …); scannability greps 0 (no placeholders/secrets, 1 H1, no dup slugs, no bare fences); hero diagram accurate (#348) + mermaid-lint clean. H1 ↔ About aligned on subject nouns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)