### PR TITLE
refactor(test): fix compex→complex test-package typo

### DIFF
--- a/src/test/java/jsonparse/databinding/complex/gson/ComplexDataBindingGsonTest.java
+++ b/src/test/java/jsonparse/databinding/complex/gson/ComplexDataBindingGsonTest.java
@@ -1,18 +1,17 @@
-package jsonparse.databinding.compex.jackson;
+package jsonparse.databinding.complex.gson;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
-import jsonparse.databinding.complex.jackson.ComplexDataBindingJackson;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class ComplexDataBindingJacksonTest {
+class ComplexDataBindingGsonTest {
 
   @Test
-  @DisplayName("Jackson full-schema binding reports NEO count, hazardous count, and fastest NEO")
+  @DisplayName("Gson full-schema binding reports NEO count, hazardous count, and fastest NEO")
   void bindsFullSchemaAndComputesAggregates() throws Exception {
     String out = captureMain();
     assertTrue(out.contains("NEO count: 101"), out);
@@ -25,7 +24,7 @@ class ComplexDataBindingJacksonTest {
     ByteArrayOutputStream buffer = new ByteArrayOutputStream();
     System.setOut(new PrintStream(buffer, true, StandardCharsets.UTF_8));
     try {
-      ComplexDataBindingJackson.main(new String[] {});
+      ComplexDataBindingGson.main(new String[] {});
     } finally {
       System.setOut(original);
     }

--- a/src/test/java/jsonparse/databinding/complex/jackson/ComplexDataBindingJacksonTest.java
+++ b/src/test/java/jsonparse/databinding/complex/jackson/ComplexDataBindingJacksonTest.java
@@ -1,18 +1,17 @@
-package jsonparse.databinding.compex.gson;
+package jsonparse.databinding.complex.jackson;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
-import jsonparse.databinding.complex.gson.ComplexDataBindingGson;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class ComplexDataBindingGsonTest {
+class ComplexDataBindingJacksonTest {
 
   @Test
-  @DisplayName("Gson full-schema binding reports NEO count, hazardous count, and fastest NEO")
+  @DisplayName("Jackson full-schema binding reports NEO count, hazardous count, and fastest NEO")
   void bindsFullSchemaAndComputesAggregates() throws Exception {
     String out = captureMain();
     assertTrue(out.contains("NEO count: 101"), out);
@@ -25,7 +24,7 @@ class ComplexDataBindingGsonTest {
     ByteArrayOutputStream buffer = new ByteArrayOutputStream();
     System.setOut(new PrintStream(buffer, true, StandardCharsets.UTF_8));
     try {
-      ComplexDataBindingGson.main(new String[] {});
+      ComplexDataBindingJackson.main(new String[] {});
     } finally {
       System.setOut(original);
     }


### PR DESCRIPTION
Renames the pre-existing `src/test/java/jsonparse/databinding/compex/` typo directory to `complex/`, mirroring the main source package (`jsonparse.databinding.complex.{jackson,gson}`). Tests now share the package of the classes under test, so the redundant cross-package imports were dropped. The last outstanding item from this session's review chain (flagged in #347). No behaviour change — 13/13 unit tests + static-check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)