### PR TITLE
fix(makefile): guard release target against a pre-existing tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -318,6 +318,8 @@ release: deps
 	@if ! echo "$(VERSION)" | grep -qE '$(SEMVER_RE)'; then \
 		echo "Error: VERSION must be valid semver (e.g., 1.0.0 → creates tag v1.0.0)"; exit 1; \
 	fi
+	@if git rev-parse -q --verify "refs/tags/v$(VERSION)" >/dev/null 2>&1; then echo "ERROR: tag v$(VERSION) already exists locally. Pick a new version or delete it: git tag -d v$(VERSION)"; exit 1; fi
+	@if git ls-remote --exit-code --tags origin "refs/tags/v$(VERSION)" >/dev/null 2>&1; then echo "ERROR: tag v$(VERSION) already exists on origin. Pick a new version."; exit 1; fi
 	@echo "Releasing version $(VERSION) (current: $(CURRENTTAG))..."
 	@echo -n "Proceed? [y/N] " && read ans && [ "$${ans:-N}" = y ] || { echo "Aborted."; exit 1; }
 	@mvn -B versions:set -DnewVersion=$(VERSION) -DgenerateBackupPoms=false


### PR DESCRIPTION
The `release` target ran `mvn versions:set` + `git commit` before `git tag v$(VERSION)` with no check that the tag was free. Re-running with an already-existing tag left a dangling "release: cut X" commit while `git tag` aborted (Makefile Safety Check #16).

This adds local (`git rev-parse --verify`) and remote (`git ls-remote`) tag pre-existence checks at the top of the recipe — before the confirm prompt and any mutation (`mvn versions:set`/`git commit`) — failing fast with an actionable message.

Verified: `make -n release` parses; running `make release VERSION=9.9.9` against a temporary existing `v9.9.9` tag errors at the guard before any commit/mutation and leaves the tree clean.